### PR TITLE
updated workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -178,7 +178,7 @@ jobs:
           ATTEMPT=1
           while [ $ATTEMPT -le $MAX_ATTEMPTS ]; do
             echo "Attempt $ATTEMPT of $MAX_ATTEMPTS..."
-            if uv pip install --system --index-url https://test.pypi.org/simple/ --no-deps "web-hacker==$VERSION" 2>/dev/null; then
+            if uv pip install --system --pre --index-url https://test.pypi.org/simple/ --no-deps "web-hacker==$VERSION" 2>/dev/null; then
               echo "Successfully installed from TestPyPI"
               break
             fi


### PR DESCRIPTION
- Use unique .dev{timestamp} versions for TestPyPI to avoid version conflicts
- Add --pre flag to install pre-release .dev versions from TestPyPI
- Add retry loops (10 attempts) for both TestPyPI and PyPI install verification
- Only run TestPyPI publishing on PRs to main from same repo (not forks)
- Remove local install test step (redundant with TestPyPI verification)