### PR TITLE
Initialize routine result counter from existing files

### DIFF
--- a/bluebox/agents/bluebox_agent.py
+++ b/bluebox/agents/bluebox_agent.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import itertools
 import json
+import re
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime
 from pathlib import Path
@@ -180,7 +181,9 @@ class BlueBoxAgent(AbstractAgent):
 
         self._workspace = workspace or LocalWorkspace()
         self._routine_cache: dict[str, RoutineInfo] = {}
-        self._routine_execution_counter = itertools.count(1)
+        self._routine_execution_counter = itertools.count(
+            self._get_next_routine_result_index()
+        )
 
         # Load context from explicit path or auto-discover from workspace
         self._agent_context: BlueBoxAgentContext | None = self._load_context(context_file)
@@ -310,6 +313,18 @@ class BlueBoxAgent(AbstractAgent):
     ## Context loading
 
     _CONTEXT_PROMPT_MAX_CHARS: int = 20_000
+    _ROUTINE_RESULT_PATTERN = re.compile(r"-routine_result_(\d+)\.json$")
+
+    def _get_next_routine_result_index(self) -> int:
+        """Scan raw/ for existing routine_result files and return max index + 1."""
+        raw_dir = self._workspace.root_path / "raw"
+        max_idx = 0
+        if raw_dir.is_dir():
+            for f in raw_dir.iterdir():
+                m = self._ROUTINE_RESULT_PATTERN.search(f.name)
+                if m:
+                    max_idx = max(max_idx, int(m.group(1)))
+        return max_idx + 1
 
     def _load_context(self, context_file: str | None) -> BlueBoxAgentContext | None:
         """Load context from an explicit path or auto-discover from workspace context/ dir.

--- a/tests/unit/agents/test_bluebox_agent_execution_counter.py
+++ b/tests/unit/agents/test_bluebox_agent_execution_counter.py
@@ -23,14 +23,18 @@ from bluebox.agents.workspace import LocalWorkspace
 # =============================================================================
 
 
-@pytest.fixture
-def agent(tmp_path: Path) -> BlueBoxAgent:
+def _make_agent(tmp_path: Path) -> BlueBoxAgent:
     """Create a BlueBoxAgent with a local workspace for testing."""
     return BlueBoxAgent(
         emit_message_callable=MagicMock(),
         workspace=LocalWorkspace(str(tmp_path)),
         auth_headers_provider=lambda: {"X-Service-Token": "test"},
     )
+
+
+@pytest.fixture
+def agent(tmp_path: Path) -> BlueBoxAgent:
+    return _make_agent(tmp_path)
 
 
 def _mock_response(json_data: dict) -> MagicMock:
@@ -136,3 +140,65 @@ class TestRoutineResultFilenameIndex:
         assert len(raw_files) == 10
         indices = sorted(int(f.stem.split("_")[-1]) for f in raw_files)
         assert indices == list(range(1, 11))
+
+
+class TestCounterResumesFromExistingFiles:
+    """Tests that the counter initializes from existing files in raw/."""
+
+    def test_empty_raw_starts_at_1(self, tmp_path: Path) -> None:
+        """No existing files means counter starts at 1."""
+        agent = _make_agent(tmp_path)
+        assert next(agent._routine_execution_counter) == 1
+
+    def test_resumes_after_existing_files(self, tmp_path: Path) -> None:
+        """If raw/ has files with indices 1-3, counter starts at 4."""
+        raw_dir = tmp_path / "raw"
+        raw_dir.mkdir(parents=True, exist_ok=True)
+        for i in range(1, 4):
+            (raw_dir / f"26-02-23-120000-routine_result_{i}.json").write_text("{}")
+
+        agent = _make_agent(tmp_path)
+        assert next(agent._routine_execution_counter) == 4
+
+    def test_resumes_from_max_not_count(self, tmp_path: Path) -> None:
+        """If files have gaps (e.g. 1, 3, 5), counter starts at max+1 = 6."""
+        raw_dir = tmp_path / "raw"
+        raw_dir.mkdir(parents=True, exist_ok=True)
+        for i in [1, 3, 5]:
+            (raw_dir / f"26-02-23-120000-routine_result_{i}.json").write_text("{}")
+
+        agent = _make_agent(tmp_path)
+        assert next(agent._routine_execution_counter) == 6
+
+    def test_ignores_non_matching_files(self, tmp_path: Path) -> None:
+        """Files that don't match the pattern are ignored."""
+        raw_dir = tmp_path / "raw"
+        raw_dir.mkdir(parents=True, exist_ok=True)
+        (raw_dir / "some_other_file.json").write_text("{}")
+        (raw_dir / "26-02-23-120000-routine_result_3.json").write_text("{}")
+
+        agent = _make_agent(tmp_path)
+        assert next(agent._routine_execution_counter) == 4
+
+    @patch("bluebox.agents.bluebox_agent.requests.post")
+    def test_new_execution_continues_from_existing(
+        self, mock_post: MagicMock, tmp_path: Path,
+    ) -> None:
+        """A new agent with existing files should save the next file correctly."""
+        raw_dir = tmp_path / "raw"
+        raw_dir.mkdir(parents=True, exist_ok=True)
+        for i in range(1, 4):
+            (raw_dir / f"26-02-23-120000-routine_result_{i}.json").write_text("{}")
+
+        mock_post.return_value = _mock_response({"result": {"data": "ok"}})
+        agent = _make_agent(tmp_path)
+
+        agent._execute_routines_in_parallel(routine_executions=[
+            MagicMock(routine_id="r1", parameters={}),
+            MagicMock(routine_id="r2", parameters={}),
+        ])
+
+        raw_files = sorted((tmp_path / "raw").glob("*routine_result_*.json"))
+        assert len(raw_files) == 5
+        indices = sorted(int(f.stem.split("_")[-1]) for f in raw_files)
+        assert indices == [1, 2, 3, 4, 5]


### PR DESCRIPTION
## Summary

- On agent init, scan `raw/` for existing `routine_result_{N}.json` files and seed the counter at `max(N) + 1`, so new agent instances against an existing workspace never overwrite prior results
- Added 5 new unit tests for resume-from-existing-files behavior: empty raw starts at 1, resumes from existing, handles index gaps, ignores non-matching files, and end-to-end continuation