### PR TITLE
Use detailed step history from server SSE when available

### DIFF
--- a/bluebox/agents/bluebox_agent.py
+++ b/bluebox/agents/bluebox_agent.py
@@ -692,7 +692,7 @@ class BlueBoxAgent(AbstractAgent):
                     "n_steps": event.n_steps,
                     "duration_seconds": event.duration_seconds,
                     "execution_id": event.execution_id,
-                    "steps": steps,
+                    "steps": data.get("steps_detail", steps),  # prefer detailed steps from server if available
                     "prompt_tokens": event.prompt_tokens,
                     "completion_tokens": event.completion_tokens,
                     "total_tokens": event.total_tokens,


### PR DESCRIPTION
In `_consume_sse_stream`, prefer `steps_detail` from the raw SSE data dict over the minimal `steps` list. The server enriches the done event with action names, params, results, URLs, and timing per step. This data flows into the tool result and gets persisted in the `ChatThread`. Falls back to the existing minimal steps list if the field is absent.